### PR TITLE
Massive dependency updates

### DIFF
--- a/akka/src/main/scala/io/kagera/akka/actor/PetriNetInstanceApi.scala
+++ b/akka/src/main/scala/io/kagera/akka/actor/PetriNetInstanceApi.scala
@@ -6,7 +6,6 @@ import akka.pattern.ask
 import akka.stream.scaladsl.{ Sink, Source, SourceQueueWithComplete }
 import akka.stream.{ Materializer, OverflowStrategy }
 import akka.util.Timeout
-import cats.data.Xor
 import io.kagera.akka.actor.PetriNetInstanceProtocol._
 import io.kagera.api.colored.ExceptionStrategy.RetryWithDelay
 import io.kagera.api.colored.{ Transition, _ }
@@ -79,29 +78,29 @@ class PetriNetInstanceApi[S](topology: ExecutablePetriNet[S], actor: ActorRef)(i
   /**
    * Fires a transition and confirms (waits) for the result of that transition firing.
    */
-  def askAndConfirmFirst(msg: Any)(implicit timeout: Timeout): Future[Xor[UnexpectedMessage, InstanceState[S]]] = {
+  def askAndConfirmFirst(msg: Any)(implicit timeout: Timeout): Future[Either[UnexpectedMessage, InstanceState[S]]] = {
     actor.ask(msg).map {
-      case e: TransitionFired[_] ⇒ Xor.Right(e.result.asInstanceOf[InstanceState[S]])
-      case msg @ _               ⇒ Xor.Left(UnexpectedMessage(s"Received unexepected message: $msg"))
+      case e: TransitionFired[_] ⇒ Right(e.result.asInstanceOf[InstanceState[S]])
+      case msg @ _               ⇒ Left(UnexpectedMessage(s"Received unexepected message: $msg"))
     }
   }
 
-  def askAndConfirmFirstSync(msg: Any)(implicit timeout: Timeout): Xor[UnexpectedMessage, InstanceState[S]] = {
+  def askAndConfirmFirstSync(msg: Any)(implicit timeout: Timeout): Either[UnexpectedMessage, InstanceState[S]] = {
     Await.result(askAndConfirmFirst(topology, msg), timeout.duration)
   }
 
   /**
    * Fires a transition and confirms (waits) for all responses of subsequent automated transitions.
    */
-  def askAndConfirmAll(msg: Any, waitForRetries: Boolean = false)(implicit timeout: Timeout): Future[Xor[ErrorResponse, InstanceState[S]]] = {
+  def askAndConfirmAll(msg: Any, waitForRetries: Boolean = false)(implicit timeout: Timeout): Future[Either[ErrorResponse, InstanceState[S]]] = {
 
     val futureMessages = askAndCollectAll(msg, waitForRetries).runWith(Sink.seq)
 
     futureMessages.map {
       _.lastOption match {
-        case Some(e: TransitionFired[_]) ⇒ Xor.Right(e.result.asInstanceOf[InstanceState[S]])
-        case Some(msg)                   ⇒ Xor.Left(UnexpectedMessage(s"Received unexpected message: $msg"))
-        case None                        ⇒ Xor.Left(UnknownProcessId)
+        case Some(e: TransitionFired[_]) ⇒ Right(e.result.asInstanceOf[InstanceState[S]])
+        case Some(msg)                   ⇒ Left(UnexpectedMessage(s"Received unexpected message: $msg"))
+        case None                        ⇒ Left(UnknownProcessId)
       }
     }
   }
@@ -127,8 +126,8 @@ class PetriNetInstanceApi[S](topology: ExecutablePetriNet[S], actor: ActorRef)(i
    */
   def askAndCollectAll(msg: Any, waitForRetries: Boolean = false): Source[TransitionResponse, NotUsed] = {
     askSource[Any](actor, msg, takeWhileNotFailed(topology, waitForRetries)).map {
-      case e: TransitionResponse ⇒ Xor.Right(e)
-      case msg @ _               ⇒ Xor.Left(s"Received unexpected message: $msg")
-    }.takeWhile(_.isRight).map(_.asInstanceOf[Xor.Right[TransitionResponse]].b)
+      case e: TransitionResponse ⇒ Right(e)
+      case msg @ _               ⇒ Left(s"Received unexpected message: $msg")
+    }.takeWhile(_.isRight).map(_.asInstanceOf[Right[NotUsed, TransitionResponse]].value)
   }
 }

--- a/akka/src/main/scala/io/kagera/execution/package.scala
+++ b/akka/src/main/scala/io/kagera/execution/package.scala
@@ -3,13 +3,13 @@ package io.kagera
 import java.io.{ PrintWriter, StringWriter }
 
 import cats.data.State
-import fs2.{ Strategy, Task }
+import cats.effect.IO
 import io.kagera.api._
 import io.kagera.api.colored._
 import io.kagera.execution.EventSourcing._
 
 import scala.collection.Set
-import scala.util.Random
+import scala.concurrent.ExecutionContext
 
 package object execution {
 

--- a/akka/src/test/scala/io/kagera/akka/PetriNetInstanceSpec.scala
+++ b/akka/src/test/scala/io/kagera/akka/PetriNetInstanceSpec.scala
@@ -3,7 +3,6 @@ package io.kagera.akka
 import java.util.UUID
 
 import akka.actor.{ ActorSystem, PoisonPill, Terminated }
-import fs2.Strategy
 import io.kagera.akka.PetriNetInstanceSpec._
 import io.kagera.akka.actor.PetriNetInstance
 import io.kagera.akka.actor.PetriNetInstance.Settings
@@ -13,6 +12,7 @@ import io.kagera.api.colored._
 import io.kagera.api.colored.dsl._
 import org.scalatest.time.{ Milliseconds, Span }
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 object PetriNetInstanceSpec {
@@ -243,7 +243,7 @@ class PetriNetInstanceSpec extends AkkaTestBase {
       val ttl = 500 milliseconds
 
       val customSettings = Settings(
-        evaluationStrategy = Strategy.fromCachedDaemonPool("Kagera.CachedThreadPool"),
+        evaluationStrategy = ExecutionContext.Implicits.global,
         idleTTL = Some(ttl)
       )
 

--- a/akka/src/test/scala/io/kagera/akka/QuerySpec.scala
+++ b/akka/src/test/scala/io/kagera/akka/QuerySpec.scala
@@ -2,7 +2,7 @@ package io.kagera.akka
 
 import akka.actor.ActorSystem
 import akka.persistence.query.PersistenceQuery
-import akka.persistence.query.scaladsl.{ AllPersistenceIdsQuery, CurrentEventsByPersistenceIdQuery, ReadJournal }
+import akka.persistence.query.scaladsl.{CurrentEventsByPersistenceIdQuery, ReadJournal}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.testkit.{ ImplicitSender, TestKit }
@@ -32,7 +32,7 @@ class QuerySpec extends TestKit(ActorSystem("QuerySpec", AkkaTestBase.defaultTes
 
       override def readJournal =
         PersistenceQuery(system).readJournalFor("inmemory-read-journal")
-          .asInstanceOf[ReadJournal with CurrentEventsByPersistenceIdQuery with AllPersistenceIdsQuery]
+          .asInstanceOf[ReadJournal with CurrentEventsByPersistenceIdQuery]
 
       val p1 = Place[Unit](id = 1)
       val p2 = Place[Unit](id = 2)

--- a/api/src/main/scala/io/kagera/api/colored/TransitionExecutor.scala
+++ b/api/src/main/scala/io/kagera/api/colored/TransitionExecutor.scala
@@ -1,6 +1,6 @@
 package io.kagera.api.colored
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api._
 
 trait TransitionExecutor[State] {
@@ -27,16 +27,16 @@ class TransitionExecutorImpl[State](topology: ColoredPetriNet) extends Transitio
   def fireTransition[Input, Output](t: Transition[Input, Output, State]): TransitionFunction[Input, Output, State] = {
     (consume, state, input) ⇒
 
-      def handleFailure: PartialFunction[Throwable, Task[(Marking, Output)]] = {
-        case e: Throwable ⇒ Task.fail(e)
+      def handleFailure: PartialFunction[Throwable, IO[(Marking, Output)]] = {
+        case e: Throwable ⇒ IO.raiseError(e).asInstanceOf[IO[(Marking, Output)]]
       }
 
       if (consume.multiplicities != topology.inMarking(t)) {
-        Task.fail(new IllegalArgumentException(s"Transition $t may not consume $consume"))
+        IO.raiseError(new IllegalArgumentException(s"Transition $t may not consume $consume"))
       }
 
       try {
-        transitionFunction(t)(consume, state, input).handleWith { handleFailure }
+        transitionFunction(t)(consume, state, input).handleErrorWith { handleFailure }
       } catch { handleFailure }
   }
 }

--- a/api/src/main/scala/io/kagera/api/colored/dsl/SequenceNet.scala
+++ b/api/src/main/scala/io/kagera/api/colored/dsl/SequenceNet.scala
@@ -1,6 +1,6 @@
 package io.kagera.api.colored.dsl
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api.colored.ExceptionStrategy.BlockTransition
 import io.kagera.api.colored._
 import io.kagera.api.colored.transitions.{ AbstractTransition, UncoloredTransition }
@@ -11,7 +11,7 @@ case class TransitionBehaviour[S, E](automated: Boolean, exceptionHandler: Trans
   def asTransition(id: Long, eventSource: S ⇒ E ⇒ S) = new AbstractTransition[Unit, E, S](id, s"t$id", automated, Duration.Undefined, exceptionHandler) with UncoloredTransition[Unit, E, S] {
     override val toString = label
     override val updateState = eventSource
-    override def produceEvent(consume: Marking, state: S, input: Unit): Task[E] = Task.delay { (fn(state)) }
+    override def produceEvent(consume: Marking, state: S, input: Unit): IO[E] = IO.delay { (fn(state)) }
   }
 }
 

--- a/api/src/main/scala/io/kagera/api/colored/dsl/StateTransitionNet.scala
+++ b/api/src/main/scala/io/kagera/api/colored/dsl/StateTransitionNet.scala
@@ -1,6 +1,6 @@
 package io.kagera.api.colored.dsl
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api.colored.ExceptionStrategy.BlockTransition
 import io.kagera.api.colored.transitions.{ AbstractTransition, UncoloredTransition }
 import io.kagera.api.colored.{ Marking, Transition, _ }
@@ -17,7 +17,7 @@ trait StateTransitionNet[S, E] {
     new AbstractTransition[Unit, E, S](id, label.getOrElse(s"t$id"), automated, Duration.Undefined, exceptionStrategy) with UncoloredTransition[Unit, E, S] {
       override val toString = label
       override val updateState = eventSourcing
-      override def produceEvent(consume: Marking, state: S, input: Unit): Task[E] = Task.delay { (fn(state)) }
+      override def produceEvent(consume: Marking, state: S, input: Unit): IO[E] = IO.delay { (fn(state)) }
     }
 
   def createPetriNet(arcs: Arc*) = process[S](arcs: _*)

--- a/api/src/main/scala/io/kagera/api/colored/dsl/package.scala
+++ b/api/src/main/scala/io/kagera/api/colored/dsl/package.scala
@@ -1,6 +1,6 @@
 package io.kagera.api.colored
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api._
 import io.kagera.api.colored.transitions.{ AbstractTransition, IdentityTransition }
 import io.kagera.api.multiset._
@@ -44,7 +44,7 @@ package object dsl {
       override val toString = label
 
       override def apply(inAdjacent: MultiSet[Place[_]], outAdjacent: MultiSet[Place[_]]) =
-        (marking, state, input) ⇒ Task.delay {
+        (marking, state, input) ⇒ IO.delay {
           val produced = outAdjacent.map {
             case (place, weight) ⇒ place -> Map(constant -> weight)
           }.toMarking

--- a/api/src/main/scala/io/kagera/api/colored/package.scala
+++ b/api/src/main/scala/io/kagera/api/colored/package.scala
@@ -1,9 +1,10 @@
 package io.kagera.api
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api.multiset._
 
 import scala.language.existentials
+import scala.language.higherKinds
 import scalax.collection.Graph
 import scalax.collection.edge.WLDiEdge
 
@@ -33,7 +34,7 @@ package object colored {
    * @tparam Output The output emitted by the transition.
    * @tparam State  The state the transition closes over.
    */
-  type TransitionFunction[Input, Output, State] = (Marking, State, Input) ⇒ Task[(Marking, Output)]
+  type TransitionFunction[Input, Output, State] = (Marking, State, Input) ⇒ IO[(Marking, Output)]
 
   /**
    * An exception handler function associated with a transition.

--- a/api/src/main/scala/io/kagera/api/colored/transitions/UncoloredTransition.scala
+++ b/api/src/main/scala/io/kagera/api/colored/transitions/UncoloredTransition.scala
@@ -1,6 +1,6 @@
 package io.kagera.api.colored.transitions
 
-import fs2.Task
+import cats.effect.IO
 import io.kagera.api.colored._
 import io.kagera.api.multiset.{ MultiSet, _ }
 
@@ -17,5 +17,5 @@ trait UncoloredTransition[Input, Output, State] extends Transition[Input, Output
       }
   }
 
-  def produceEvent(consume: Marking, state: State, input: Input): Task[Output]
+  def produceEvent(consume: Marking, state: State, input: Input): IO[Output]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val akka = Project("akka", file("akka"))
     defaultProjectSettings ++ Seq(
       name := "kagera-akka",
       libraryDependencies ++= Seq(
-        scalaReflect,
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         akkaActor,
         akkaPersistence,
         akkaSlf4j,
@@ -56,7 +56,10 @@ lazy val demo = (crossProject(JSPlatform, JVMPlatform) in file("demo"))
   .settings(defaultProjectSettings: _*)
   .settings(
     unmanagedSourceDirectories in Compile += baseDirectory.value / "shared" / "main" / "scala",
-    libraryDependencies ++= Seq("com.lihaoyi" %%% "scalatags" % "0.4.6", "com.lihaoyi" %%% "upickle" % "0.4.2")
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %%% "scalatags" % "0.9.1",
+      "com.lihaoyi" %%% "upickle" % "1.1.0"
+    )
   )
   .jsSettings(
     jsDependencies ++= Seq(
@@ -65,13 +68,13 @@ lazy val demo = (crossProject(JSPlatform, JVMPlatform) in file("demo"))
         minified s"$cytoscapeVersion/dist/cytoscape.min.js"
         commonJSName "cytoscape"
     ),
-    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "0.8.0")
+    libraryDependencies ++= Seq("org.scala-js" %%% "scalajs-dom" % "1.0.0")
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "de.heikoseeberger" %% "akka-http-upickle" % "1.10.1",
+      "de.heikoseeberger" %% "akka-http-upickle" % "1.32.0",
       akkaHttp,
-      akkaPersistenceQuery,
+      akkaQuery,
       akkaPersistenceCassandra
     ),
     name := "demo-app",

--- a/demo/js/src/main/scala/io/kagera/frontend/Api.scala
+++ b/demo/js/src/main/scala/io/kagera/frontend/Api.scala
@@ -3,6 +3,7 @@ package io.kagera.frontend
 import io.kagera.demo.model.{ PetriNetModel, ProcessState }
 import org.scalajs.dom.ext.Ajax
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import upickle.default._
 
 import scala.concurrent.Future
 

--- a/demo/js/src/main/scala/io/kagera/frontend/Client.scala
+++ b/demo/js/src/main/scala/io/kagera/frontend/Client.scala
@@ -4,10 +4,10 @@ import io.kagera.frontend.cytoscape._
 import org.scalajs.dom.html
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation.{ JSExport, JSExportTopLevel }
 import scalatags.JsDom.all._
 
-@JSExport
+@JSExportTopLevel("Client")
 object Client extends {
 
   @JSExport

--- a/demo/js/src/main/scala/io/kagera/frontend/cytoscape/CytoScape.scala
+++ b/demo/js/src/main/scala/io/kagera/frontend/cytoscape/CytoScape.scala
@@ -3,9 +3,9 @@ package io.kagera.frontend.cytoscape
 import org.scalajs.dom.html
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.{ JSExportTopLevel, JSGlobal, JSName }
 
-@JSName("cytoscape")
+@JSGlobal("cytoscape")
 @js.native
 protected object CytoScapeJS extends js.Object {
 

--- a/demo/jvm/src/main/scala/io/kagera/demo/http/Routes.scala
+++ b/demo/jvm/src/main/scala/io/kagera/demo/http/Routes.scala
@@ -12,6 +12,7 @@ import io.kagera.akka.actor.PetriNetInstance
 import io.kagera.akka.actor.PetriNetInstanceProtocol._
 import io.kagera.api.colored.{ExecutablePetriNet, Generators, Marking}
 import io.kagera.demo.{ConfiguredActorSystem, Queries}
+import upickle.default._
 
 trait Routes extends Directives with Queries with UpickleSupport {
 

--- a/demo/shared/src/main/scala/io/kagera/demo/model/package.scala
+++ b/demo/shared/src/main/scala/io/kagera/demo/model/package.scala
@@ -1,13 +1,23 @@
 package io.kagera.demo
 
+import upickle.default._
 
 package object model {
 
   case class Place(id: Long, label: String)
+  object Place {
+    implicit val rw: ReadWriter[Place] = macroRW[Place]
+  }
 
   case class Transition(id: Long, label: String, code: String = "", input: Option[String] = None)
+  object Transition {
+    implicit val rw: ReadWriter[Transition] = macroRW[Transition]
+  }
 
   case class Edge(source: String, target: String, weigth: Int = 1)
+  object Edge {
+    implicit val rw: ReadWriter[Edge] = macroRW[Edge]
+  }
 
   case class PetriNetModel(
                             places: Set[Place],
@@ -15,6 +25,9 @@ package object model {
                             edges: Set[Edge]) {
 
     def nodes: Set[Either[Place, Transition]] = places.map(p => Left(p)) ++ transitions.map(t => Right(t))
+  }
+  object PetriNetModel {
+    implicit val rw: ReadWriter[PetriNetModel] = macroRW[PetriNetModel]
   }
 
   case class ProcessState(marking: Map[Long, Int], data: Map[String, String])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,26 +14,24 @@ object Dependencies {
   val akkaTestkit              = "com.typesafe.akka"               %% "akka-testkit"                        % akkaVersion
   val akkaSlf4j                = "com.typesafe.akka"               %% "akka-slf4j"                          % akkaVersion
   val akkaStream               = "com.typesafe.akka"               %% "akka-stream"                         % akkaVersion
-  val akkaQuery                = "com.typesafe.akka"               %% "akka-persistence-query-experimental" % akkaVersion
-  val akkaHttp                 = "com.typesafe.akka"               %% "akka-http-experimental"              % akkaHttpVersion
-  val akkaInmemoryJournal      = "com.github.dnvriend"             %% "akka-persistence-inmemory"           % "1.3.14"
+  val akkaQuery                = "com.typesafe.akka"               %% "akka-persistence-query"              % akkaVersion
+  val akkaHttp                 = "com.typesafe.akka"               %% "akka-http"                           % "10.1.12"
+  val akkaInmemoryJournal      = "com.github.dnvriend"             %% "akka-persistence-inmemory"           % "2.5.15.2"
 
   val akkaAnalyticsCassandra   = "com.github.krasserm"             %% "akka-analytics-cassandra"   % "0.3.1"
   val akkaAnalyticsKafka       = "com.github.krasserm"             %% "akka-analytics-kafka"       % "0.3.1"
 
   val scalazCore               = "org.scalaz"                      %% "scalaz-core"               % "7.2.6"
 
-  val akkaPersistenceCassandra = "com.typesafe.akka"               %% "akka-persistence-cassandra" % "0.18"
-  val akkaPersistenceQuery     = "com.typesafe.akka"               %% "akka-persistence-query-experimental" % akkaVersion
+  val akkaPersistenceCassandra = "com.typesafe.akka"               %% "akka-persistence-cassandra" % "0.103"
 
-  val scalaGraph               = "com.assembla.scala-incubator"    %% "graph-core"             % "1.10.1"
-  val scalaGraphDot            = "com.assembla.scala-incubator"    %% "graph-dot"              % "1.10.1"
+  val scalaGraph               = "org.scala-graph"                 %% "graph-core"             % "1.12.5"
+  val scalaGraphDot            = "org.scala-graph"                 %% "graph-dot"              % "1.11.5"
 
-  val fs2Core                  = "co.fs2"                          %% "fs2-core"               % "0.9.1"
-  val catsCore                 = "org.typelevel"                   %% "cats-core"              % "0.7.2"
+  val fs2Core                  = "co.fs2"                          %% "fs2-core"               % "2.1.0"
+  val catsCore                 = "org.typelevel"                   %% "cats-core"              % "2.0.0"
 
   val logback                  = "ch.qos.logback"                  %  "logback-classic"        % "1.1.2"
   val ficus                    = "net.ceedubs"                     %% "ficus"                  % "1.1.2"
-  val scalaReflect             = "org.scala-lang"                  % "scala-reflect"           % "2.11.12"
-  val scalatest                = "org.scalatest"                   %% "scalatest"              % "2.2.1"
+  val scalatest                = "org.scalatest"                   %% "scalatest"              % "3.0.8"
 }


### PR DESCRIPTION
I'm currently experimenting with using Kagera instead of Baker for a use case where Baker does not seem suitable (https://github.com/ing-bank/baker/issues/541).
I've brought the dependencies more or less up-to-date so that the project compiles and tests run under Scala 2.12.
Another question in that regard:
Why wasn't Kagera used as a base library for Baker?
It would seem useful to have one library that is focused on Petri Nets themselves and then build Akka, recipe compilation, etc. on top of that.