### PR TITLE
Scala 2.13

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ["2.12.11", "2.11.12"]
+        scala: ["2.13.3", "2.12.12"]
 
     runs-on: ubuntu-latest
 

--- a/api/src/main/scala/io/kagera/api/colored/package.scala
+++ b/api/src/main/scala/io/kagera/api/colored/package.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import io.kagera.api.multiset._
 
 import scala.language.existentials
+import scala.collection.compat._
 import scala.language.higherKinds
 import scalax.collection.Graph
 import scalax.collection.edge.WLDiEdge
@@ -56,7 +57,7 @@ package object colored {
    */
   implicit class MarkingAdditions(marking: Marking) {
 
-    def multiplicities: MultiSet[Place[_]] = marking.data.mapValues(_.multisetSize)
+    def multiplicities: MultiSet[Place[_]] = marking.data.view.mapValues(_.multisetSize).toMap
 
     def add[C](p: Place[C], value: C, count: Int = 1): Marking = {
       val newTokens = marking.getOrElse(p, MultiSet.empty).multisetIncrement(value, count)

--- a/api/src/main/scala/io/kagera/api/package.scala
+++ b/api/src/main/scala/io/kagera/api/package.scala
@@ -47,7 +47,7 @@ package object api {
     }
   }
 
-  type BiPartiteGraph[P, T, E[X] <: EdgeLikeIn[X]] = Graph[Either[P, T], E]
+  type BiPartiteGraph[P, T, E[+X] <: EdgeLikeIn[X]] = Graph[Either[P, T], E]
 
   /**
    * TODO; can we remove this wrapper? It seems only needed because we need to mix in other traits with PetriNet which

--- a/build.sbt
+++ b/build.sbt
@@ -13,15 +13,15 @@ val commonScalacOptions = Seq(
 )
 
 lazy val basicSettings =
-  Seq(organization := "io.kagera", crossScalaVersions := Seq("2.12.12"), scalaVersion := crossScalaVersions.value.head, scalacOptions := commonScalacOptions)
+  Seq(organization := "io.kagera", crossScalaVersions := Seq("2.13.3", "2.12.12"), scalaVersion := crossScalaVersions.value.head, scalacOptions := commonScalacOptions)
 
 lazy val defaultProjectSettings = basicSettings ++ SonatypePublish.settings
 
-lazy val api = Project("api", file("api"))
+lazy val api = project.in(file("api"))
   .settings(defaultProjectSettings: _*)
-  .settings(name := "kagera-api", libraryDependencies ++= Seq(scalaGraph, catsCore, fs2Core, scalatest % "test"))
+  .settings(name := "kagera-api", libraryDependencies ++= Seq(collectionCompat, scalaGraph, catsCore, fs2Core, scalatest % "test"))
 
-lazy val visualization = Project("visualization", file("visualization"))
+lazy val visualization = project.in(file("visualization"))
   .dependsOn(api)
   .settings(defaultProjectSettings: _*)
   .settings(name := "kagera-visualization", libraryDependencies ++= Seq(scalaGraph, scalaGraphDot))

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val commonScalacOptions = Seq(
 lazy val basicSettings =
   Seq(
     organization := "io.kagera",
-    crossScalaVersions := Seq("2.12.11", "2.11.12"),
+    crossScalaVersions := Seq("2.12.12"),
     scalaVersion := crossScalaVersions.value.head,
     scalacOptions := commonScalacOptions
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,8 +25,8 @@ object Dependencies {
 
   val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.103"
 
-  val scalaGraph = "org.scala-graph" %% "graph-core" % "1.12.5"
-  val scalaGraphDot = "org.scala-graph" %% "graph-dot" % "1.11.5"
+  val scalaGraph = "org.scala-graph" %% "graph-core" % "1.13.1"
+  val scalaGraphDot = "org.scala-graph" %% "graph-dot" % "1.13.0"
 
   val fs2Core = "co.fs2" %% "fs2-core" % "2.1.0"
   val catsCore = "org.typelevel" %% "cats-core" % "2.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
   val scalazVersion = "7.1.3"
   val cytoscapeVersion = "2.7.9"
 
+  val collectionCompat         = "org.scala-lang.modules"          %% "scala-collection-compat"             % "2.2.0"
   val akkaActor                = "com.typesafe.akka"               %% "akka-actor"                          % akkaVersion
   val akkaPersistence          = "com.typesafe.akka"               %% "akka-persistence"                    % akkaVersion
   val akkaTestkit              = "com.typesafe.akka"               %% "akka-testkit"                        % akkaVersion

--- a/visualization/src/main/scala/io/kagera/dot/GraphDot.scala
+++ b/visualization/src/main/scala/io/kagera/dot/GraphDot.scala
@@ -8,7 +8,7 @@ import scalax.collection.io.dot.implicits._
 
 object GraphDot {
 
-  def generateDot[N, E[X] <: EdgeLikeIn[X]](graph: Graph[N, E], theme: GraphTheme[N, E]) = {
+  def generateDot[N, E[+X] <: EdgeLikeIn[X]](graph: Graph[N, E], theme: GraphTheme[N, E]): String = {
     val myRoot =
       DotRootGraph(directed = graph.isDirected, id = None, attrStmts = theme.attrStmts, attrList = theme.rootAttrs)
 
@@ -33,7 +33,7 @@ object GraphDot {
   }
 
   // TODO Generalize this for all types of graphs
-  implicit class GraphVisualization[N, E[X] <: EdgeLikeIn[X]](graph: Graph[N, E]) {
+  implicit class GraphVisualization[N, E[+X] <: EdgeLikeIn[X]](graph: Graph[N, E]) {
 
     def toDot(theme: GraphTheme[N, E]): String = generateDot(graph, theme)
   }


### PR DESCRIPTION
Unfortunately there's no way to keep it compatible with Scala 2.11 while upgrading to 2.13, but the world has to move on at some point 😉